### PR TITLE
Features/add coding guidelines

### DIFF
--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -12,87 +12,72 @@ We use the collaboration features from Github, see https://github.com/oemof.
 
 
 Style guidlines
------------------------------------------
+---------------
 
-PEP8 (Python Style Guide)
-=========================================
+### PEP8 (Python Style Guide)
 
-We adhere to “PEP8”:https://www.python.org/dev/peps/pep-0008/ for any
-code produced in the framework.
+We adhere to [PEP8] for any code produced in the framework.
 
-We use pylint to check your code. Pylint is integrated in many IDEs and
-Editors. “Check here”:http://docs.pylint.org/ide-integration or ask the
-maintainer of your IDE or Editor.
+We use pylint to check your code. Pylint is integrated in many IDEs and Editors. [Check here] or ask the maintainer of your IDE or Editor.
 
-Some IDEs have pep8 checkers, which are very helpful, especially for
-python beginners.
+Some IDEs have pep8 checkers, which are very helpful, especially for python beginners.
 
-Quoted strings
-=========================================
+### Quoted strings
 
 For strings we use double quotes if possible.
 
-.. raw:: html
+    info_msg = "We use double quotes for strings"
+    info_msg = 'This is a string where we need to use "single" quotes'
 
-   <pre><code class="python">
-   info_msg = "We use double quotes for strings"
-   info_msg = 'This is a string where we need to use "single" quotes'
-   </code></pre>
+### UML class diagrams
 
-UML class diagrams
-=========================================
+We use `pyreverse` for the creation of UML class diagrams, which will be integrated in the sphinx documentation (done by Günni).
+For example:
 
-We use @pyreverse@ for the creation of UML class diagrams, which will be
-integrated in the sphinx documentation (done by Günni). For example:
-
-.. raw:: html
-
-   <pre>
-   pyreverse -o png -p components oemof/src/components.py
-   </pre>
+    pyreverse -o png -p components oemof/src/components.py
 
 Naming Conventions
------------------------------------------
+------------------
 
-We use plural in the code for modules if there are possibly more than
-one child classes (e.g. import transformers AND NOT transformer). Arrays
-in the code if there are multiple have to be plural (e.g. @transformers
-= [T1, T2,…]@).
+We use plural in the code for modules if there are possibly more than one child classes (e.g. import transformers AND NOT transformer). Arrays in the code if there are multiple have to be plural (e.g. `transformers = [T1, T2,...]`).
 
-Please, follow the following naming conventions!!
+Please, follow the following naming conventions![]
 
-| *Type* \| *Public* \| *Internal* \|
-| Packages \| lower\_with\_under \| none \|
-| Modules \| lower\_with\_under \| \_lower\_with\_under \|
-| Classes \| CappedCamelCase \| \_CappedCamelCase \|
-| Exception \| CappedCamelCase \| \_CappedCamelCase \|
-| Functions \| lower\_with\_under() \| \_lower\_with\_under() \|
-| Global/Class Constants \| CAPS\_WITH\_UNDER \| \_CAPS\_WITH\_UNDER \|
-| Global/Class Variables \| lower\_with\_under \| \_lower\_with\_under
-  \|
-| Instance Variables \| lower\_with\_under \| \_lower\_with\_under
-  (protected) \_\_lower\_with\_under (private) \|
-| Method Names \| lower\_with\_under() \| \_lower\_with\_under()
-  (protected) \_\_lower\_with\_under() (private) \|
-| Function/Method Parameters \| lower\_with\_under \| none \|
-| Local Variables \| lower\_with\_under \| none \|
+|                            |                      |                                                                    |
+|----------------------------|----------------------|--------------------------------------------------------------------|
+| **Type**                   | **Public**           | **Internal**                                                       |
+| Packages                   | lower\_with\_under   | none                                                               |
+| Modules                    | lower\_with\_under   | \_lower\_with\_under                                               |
+| Classes                    | CappedCamelCase      | \_CappedCamelCase                                                  |
+| Exception                  | CappedCamelCase      | \_CappedCamelCase                                                  |
+| Functions                  | lower\_with\_under() | \_lower\_with\_under()                                             |
+| Global/Class Constants     | CAPS\_WITH\_UNDER    | \_CAPS\_WITH\_UNDER                                                |
+| Global/Class Variables     | lower\_with\_under   | \_lower\_with\_under                                               |
+| Instance Variables         | lower\_with\_under   | *lower\_with\_under (protected)*\_lower\_with\_under (private)     |
+| Method Names               | lower\_with\_under() | *lower\_with\_under() (protected)*\_lower\_with\_under() (private) |
+| Function/Method Parameters | lower\_with\_under   | none                                                               |
+| Local Variables            | lower\_with\_under   | none                                                               |
 
 See also: http://pylint-messages.wikidot.com/messages:c0103
 
-*Use talking names!*
+**Use talking names!**
 
-This means: \* Variables/Objects: Name it after the data they describe
-(pwer\_line, wind\_speed) \* Functions/Method: Name it after what they
-do: *use verbs* (get\_wind\_speed, set\_parameter)
+This means:
+
+-   Variables/Objects: Name it after the data they describe (pwer\_line, wind\_speed)
+-   Functions/Method: Name it after what they do: **use verbs** (get\_wind\_speed, set\_parameter)
 
 Local files (config, output, csv…)
------------------------------------------
+----------------------------------
 
-Hidden folder
-=========================================
+### Hidden folder
 
--  configuration files (e.g. oemof.cfg)
--  logging fi
+-   configuration files (e.g. oemof.cfg)
+-   logging fi
+
+  [PEP8]: https://www.python.org/dev/peps/pep-0008/
+  [Check here]: http://docs.pylint.org/ide-integration
+  []: 
 
 
 Git branching model

--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -12,6 +12,83 @@ Collaboration
 We use the collaboration features from Github, see https://github.com/oemof.
 
 
+h2. Style guidlines
+
+h3. PEP8 (Python Style Guide)
+
+We adhere to “PEP8”:https://www.python.org/dev/peps/pep-0008/ for any
+code produced in the framework.
+
+We use pylint to check your code. Pylint is integrated in many IDEs and
+Editors. “Check here”:http://docs.pylint.org/ide-integration or ask the
+maintainer of your IDE or Editor.
+
+Some IDEs have pep8 checkers, which are very helpful, especially for
+python beginners.
+
+h3. Quoted strings
+
+For strings we use double quotes if possible.
+
+.. raw:: html
+
+   <pre><code class="python">
+   info_msg = "We use double quotes for strings"
+   info_msg = 'This is a string where we need to use "single" quotes'
+   </code></pre>
+
+h3. UML class diagrams
+
+We use @pyreverse@ for the creation of UML class diagrams, which will be
+integrated in the sphinx documentation (done by Günni). For example:
+
+.. raw:: html
+
+   <pre>
+   pyreverse -o png -p components oemof/src/components.py
+   </pre>
+
+h2. Naming Conventions
+
+We use plural in the code for modules if there are possibly more than
+one child classes (e.g. import transformers AND NOT transformer). Arrays
+in the code if there are multiple have to be plural (e.g. @transformers
+= [T1, T2,…]@).
+
+Please, follow the following naming conventions!!
+
+| *Type* \| *Public* \| *Internal* \|
+| Packages \| lower\_with\_under \| none \|
+| Modules \| lower\_with\_under \| \_lower\_with\_under \|
+| Classes \| CappedCamelCase \| \_CappedCamelCase \|
+| Exception \| CappedCamelCase \| \_CappedCamelCase \|
+| Functions \| lower\_with\_under() \| \_lower\_with\_under() \|
+| Global/Class Constants \| CAPS\_WITH\_UNDER \| \_CAPS\_WITH\_UNDER \|
+| Global/Class Variables \| lower\_with\_under \| \_lower\_with\_under
+  \|
+| Instance Variables \| lower\_with\_under \| \_lower\_with\_under
+  (protected) \_\_lower\_with\_under (private) \|
+| Method Names \| lower\_with\_under() \| \_lower\_with\_under()
+  (protected) \_\_lower\_with\_under() (private) \|
+| Function/Method Parameters \| lower\_with\_under \| none \|
+| Local Variables \| lower\_with\_under \| none \|
+
+See also: http://pylint-messages.wikidot.com/messages:c0103
+
+*Use talking names!*
+
+This means: \* Variables/Objects: Name it after the data they describe
+(pwer\_line, wind\_speed) \* Functions/Method: Name it after what they
+do: *use verbs* (get\_wind\_speed, set\_parameter)
+
+h2. Local files (config, output, csv…)
+
+h3. Hidden folder
+
+-  configuration files (e.g. oemof.cfg)
+-  logging fi
+
+
 Git branching model
 -----------------------------------------
 

--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -5,16 +5,17 @@
 Here we gather important notes for the developing of oemof and elements within
 the framework.
 
-
 Collaboration
 -----------------------------------------
 
 We use the collaboration features from Github, see https://github.com/oemof.
 
 
-h2. Style guidlines
+Style guidlines
+-----------------------------------------
 
-h3. PEP8 (Python Style Guide)
+PEP8 (Python Style Guide)
+=========================================
 
 We adhere to “PEP8”:https://www.python.org/dev/peps/pep-0008/ for any
 code produced in the framework.
@@ -26,7 +27,8 @@ maintainer of your IDE or Editor.
 Some IDEs have pep8 checkers, which are very helpful, especially for
 python beginners.
 
-h3. Quoted strings
+Quoted strings
+=========================================
 
 For strings we use double quotes if possible.
 
@@ -37,7 +39,8 @@ For strings we use double quotes if possible.
    info_msg = 'This is a string where we need to use "single" quotes'
    </code></pre>
 
-h3. UML class diagrams
+UML class diagrams
+=========================================
 
 We use @pyreverse@ for the creation of UML class diagrams, which will be
 integrated in the sphinx documentation (done by Günni). For example:
@@ -48,7 +51,8 @@ integrated in the sphinx documentation (done by Günni). For example:
    pyreverse -o png -p components oemof/src/components.py
    </pre>
 
-h2. Naming Conventions
+Naming Conventions
+-----------------------------------------
 
 We use plural in the code for modules if there are possibly more than
 one child classes (e.g. import transformers AND NOT transformer). Arrays
@@ -81,16 +85,18 @@ This means: \* Variables/Objects: Name it after the data they describe
 (pwer\_line, wind\_speed) \* Functions/Method: Name it after what they
 do: *use verbs* (get\_wind\_speed, set\_parameter)
 
-h2. Local files (config, output, csv…)
+Local files (config, output, csv…)
+-----------------------------------------
 
-h3. Hidden folder
+Hidden folder
+=========================================
 
 -  configuration files (e.g. oemof.cfg)
 -  logging fi
 
 
 Git branching model
------------------------------------------
+=========================================
 
 So far we adhere mostly to the git branching model by Vincent Driessen, see
 http://nvie.com/posts/a-successful-git-branching-model/.

--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -1,12 +1,11 @@
-=========================================
- Developer Notes
-=========================================
+Developer Notes
+================
 
 Here we gather important notes for the developing of oemof and elements within
 the framework.
 
 Collaboration
------------------------------------------
+-------------
 
 We use the collaboration features from Github, see https://github.com/oemof.
 
@@ -14,87 +13,60 @@ We use the collaboration features from Github, see https://github.com/oemof.
 Style guidlines
 ---------------
 
-### PEP8 (Python Style Guide)
+We mostly follow standard guidelines instead of developing own rules.
 
-We adhere to [PEP8] for any code produced in the framework.
+PEP8 (Python Style Guide)
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We use pylint to check your code. Pylint is integrated in many IDEs and Editors. [Check here] or ask the maintainer of your IDE or Editor.
+* We adhere to `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ for any code produced in the framework.
 
-Some IDEs have pep8 checkers, which are very helpful, especially for python beginners.
+* We use pylint to check your code. Pylint is integrated in many IDEs and Editors. `Check here <http://docs.pylint.org/ide-integration>`_ or ask the maintainer of your IDE or Editor.
 
-### Quoted strings
+* Some IDEs have pep8 checkers, which are very helpful, especially for python beginners.
+
+Quoted strings
+^^^^^^^^^^^^^^
 
 For strings we use double quotes if possible.
+
+.. code-block:: python
 
     info_msg = "We use double quotes for strings"
     info_msg = 'This is a string where we need to use "single" quotes'
 
-### UML class diagrams
-
-We use `pyreverse` for the creation of UML class diagrams, which will be integrated in the sphinx documentation (done by Günni).
-For example:
-
-    pyreverse -o png -p components oemof/src/components.py
-
 Naming Conventions
 ------------------
 
-We use plural in the code for modules if there are possibly more than one child classes (e.g. import transformers AND NOT transformer). Arrays in the code if there are multiple have to be plural (e.g. `transformers = [T1, T2,...]`).
+* We use plural in the code for modules if there are possibly more than one child classes (e.g. import transformers AND NOT transformer). Arrays in the code if there are multiple have to be plural (e.g. `transformers = [T1, T2,...]`).
 
-Please, follow the following naming conventions![]
+* Please, follow the naming conventions of `pylint <http://pylint-messages.wikidot.com/messages:c0103>`_
 
-|                            |                      |                                                                    |
-|----------------------------|----------------------|--------------------------------------------------------------------|
-| **Type**                   | **Public**           | **Internal**                                                       |
-| Packages                   | lower\_with\_under   | none                                                               |
-| Modules                    | lower\_with\_under   | \_lower\_with\_under                                               |
-| Classes                    | CappedCamelCase      | \_CappedCamelCase                                                  |
-| Exception                  | CappedCamelCase      | \_CappedCamelCase                                                  |
-| Functions                  | lower\_with\_under() | \_lower\_with\_under()                                             |
-| Global/Class Constants     | CAPS\_WITH\_UNDER    | \_CAPS\_WITH\_UNDER                                                |
-| Global/Class Variables     | lower\_with\_under   | \_lower\_with\_under                                               |
-| Instance Variables         | lower\_with\_under   | *lower\_with\_under (protected)*\_lower\_with\_under (private)     |
-| Method Names               | lower\_with\_under() | *lower\_with\_under() (protected)*\_lower\_with\_under() (private) |
-| Function/Method Parameters | lower\_with\_under   | none                                                               |
-| Local Variables            | lower\_with\_under   | none                                                               |
+* Use talking names
 
-See also: http://pylint-messages.wikidot.com/messages:c0103
-
-**Use talking names!**
-
-This means:
-
--   Variables/Objects: Name it after the data they describe (pwer\_line, wind\_speed)
--   Functions/Method: Name it after what they do: **use verbs** (get\_wind\_speed, set\_parameter)
-
-Local files (config, output, csv…)
-----------------------------------
-
-### Hidden folder
-
--   configuration files (e.g. oemof.cfg)
--   logging fi
-
-  [PEP8]: https://www.python.org/dev/peps/pep-0008/
-  [Check here]: http://docs.pylint.org/ide-integration
-  []: 
+  * Variables/Objects: Name it after the data they describe (pwer\_line, wind\_speed)
+  * Functions/Method: Name it after what they do: **use verbs** (get\_wind\_speed, set\_parameter)
 
 
-Git branching model
-=========================================
+Using git
+--------- 
 
-So far we adhere mostly to the git branching model by Vincent Driessen, see
-http://nvie.com/posts/a-successful-git-branching-model/.
+branching model
+^^^^^^^^^^^^^^^
+
+So far we adhere mostly to the git branching model by `Vincent Driessen <http://nvie.com/posts/a-successful-git-branching-model/>`_.
 
 The only difference is to use a different name for the branch origin/develop 
 ("main branch where the source code of HEAD always reflects a state with the 
 latest delivered development changes for the next release. Some would call this 
 the integration branch."). The name we use is origin/dev.
 
+commit message
+^^^^^^^^^^^^^^
+
+Use this nice little `tutorial <http://chris.beams.io/posts/git-commit/>`_ to learn how to write a nice commit message.
 
 Issue-Management
------------------------------------------
-
+----------------
 Section about workflow for issues is still missing (when to assign an issue with
 what kind of tracker to whom etc.).
 

--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -43,7 +43,7 @@ Naming Conventions
 
 * Use talking names
 
-  * Variables/Objects: Name it after the data they describe (pwer\_line, wind\_speed)
+  * Variables/Objects: Name it after the data they describe (power\_line, wind\_speed)
   * Functions/Method: Name it after what they do: **use verbs** (get\_wind\_speed, set\_parameter)
 
 

--- a/doc/developer_notes.rst
+++ b/doc/developer_notes.rst
@@ -20,7 +20,7 @@ PEP8 (Python Style Guide)
 
 * We adhere to `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ for any code produced in the framework.
 
-* We use pylint to check your code. Pylint is integrated in many IDEs and Editors. `Check here <http://docs.pylint.org/ide-integration>`_ or ask the maintainer of your IDE or Editor.
+* We use pylint to check your code. Pylint is integrated in many IDEs and Editors. `Check here <http://docs.pylint.org/ide-integration>`_ or ask the maintainer of your IDE or Editor
 
 * Some IDEs have pep8 checkers, which are very helpful, especially for python beginners.
 
@@ -50,7 +50,7 @@ Naming Conventions
 Using git
 --------- 
 
-branching model
+Branching model
 ^^^^^^^^^^^^^^^
 
 So far we adhere mostly to the git branching model by `Vincent Driessen <http://nvie.com/posts/a-successful-git-branching-model/>`_.
@@ -60,7 +60,7 @@ The only difference is to use a different name for the branch origin/develop
 latest delivered development changes for the next release. Some would call this 
 the integration branch."). The name we use is origin/dev.
 
-commit message
+Commit message
 ^^^^^^^^^^^^^^
 
 Use this nice little `tutorial <http://chris.beams.io/posts/git-commit/>`_ to learn how to write a nice commit message.

--- a/doc/whatsnew/v0002.txt
+++ b/doc/whatsnew/v0002.txt
@@ -13,6 +13,7 @@ Documentation
 
  * missing docstrings of the core subpackage added (`issue #9 <https://github.com/oemof/oemof_base/issues/9>`_)
  * missing figures of the meta-documentation added
+ * missing content in developer notes (`issue #34 <https://github.com/oemof/oemof_base/issues/34>`_)
 
 Testing
 ####### 
@@ -34,3 +35,4 @@ Contributors
  * Uwe Krien
  * Simon Hilpert
  * Cord Kaldemeyer
+ * Guido Pleßmann


### PR DESCRIPTION
Missing parts of developer notes added to documentation based on [Developing Rules](http://vernetzen.uni-flensburg.de/redmine/projects/oemof/wiki/Developing_Rules) from vernetzen-Wiki. It is just an automatic translation by pandoc. So it still has formatting problems. Please help to improve formatting. Afterwards a responsible person can do the merge into dev.