### PR TITLE
Replace print by logging.info

### DIFF
--- a/doc/api/oemof.tools.rst
+++ b/doc/api/oemof.tools.rst
@@ -1,0 +1,62 @@
+oemof.tools package
+===================
+
+Submodules
+----------
+
+oemof.tools.config module
+-------------------------
+
+.. automodule:: oemof.tools.config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+oemof.tools.db module
+---------------------
+
+.. automodule:: oemof.tools.db
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+oemof.tools.entities_from_csv module
+------------------------------------
+
+.. automodule:: oemof.tools.entities_from_csv
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+oemof.tools.helpers module
+--------------------------
+
+.. automodule:: oemof.tools.helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+oemof.tools.holiday module
+--------------------------
+
+.. automodule:: oemof.tools.holiday
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+oemof.tools.logger module
+-------------------------
+
+.. automodule:: oemof.tools.logger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: oemof.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/development_examples/example_app.py
+++ b/examples/development_examples/example_app.py
@@ -29,7 +29,9 @@ from oemof.core.network.entities.components import transformers as transformer
 
 import pandas as pd
 import logging
-logging.basicConfig(filename='example_app.log', level=logging.DEBUG)
+from oemof.tools import logger
+
+logger.define_logging()
 
 data = pd.read_csv("example_data.csv", sep=",")
 timesteps = [t for t in range(168)]
@@ -99,17 +101,15 @@ sinks = [demand_th, demand_el]
 components = transformers + renew_sources + sinks
 entities = components + buses
 
-simulation = es.Simulation(
-    solver='glpk', timesteps=timesteps, stream_solver_output=True,
+simulation = es.Simulation(solver='glpk', timesteps=timesteps, verbose=False,
+                           duals=False,
     objective_options={'function': predefined_objectives.minimize_cost})
 energysystem = es.EnergySystem(entities=entities, simulation=simulation)
 
 om = OptimizationModel(energysystem=energysystem)
 
-om.solve(solver='glpk', debug=False, duals=True, verbose=True,
-         solve_kwargs={'tee':True,
-                       'keepfiles':True},
-         opt_kwargs={'solver_io':'lp'},
+om.solve(solve_kwargs={'tee':True,
+                       'keepfiles':False},
          solver_cmdline_options={'min':''})
 results = om.results()
 components = transformers + renew_sources

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -18,7 +18,7 @@ relevant input input/output uids as dictionary items.
     >>> I = {'pp_coal': 'bus_coal'}
     >>> O = {'pp_coal': ['bus_el', 'bus_th']}
     >>> print(I['pp_coal'])
-    'bus_el'
+    bus_coal
 
 
 In mathematical notation I, O can be seen as indexed index sets The

--- a/oemof/solph/optimization_model.py
+++ b/oemof/solph/optimization_model.py
@@ -75,9 +75,10 @@ class OptimizationModel(po.ConcreteModel):
 
     # TODO Cord: Take "next(iter(self.dict.values()))" where the first value of
     #            dict has to be selected
-    def __init__(self, energysystem):
-        super().__init__()
 
+    def __init__(self, energysystem, loglevel=logging.INFO):
+        super().__init__()
+        logging.basicConfig(format='%(levelname)s:%(message)s', level=loglevel)
         self.entities = energysystem.entities
         self.timesteps = energysystem.simulation.timesteps
         self.objective_options = energysystem.simulation.objective_options
@@ -288,7 +289,7 @@ class OptimizationModel(po.ConcreteModel):
             If True, duals and reduced costs are imported from the solver
             results
         verbose : boolean
-            If True informations are printed
+            If True the logging level is set from debug to info
         opt_kwargs : dict
             Other arguments for the pyomo.opt.SolverFactory() class
         solve_kwargs : dict
@@ -334,13 +335,18 @@ class OptimizationModel(po.ConcreteModel):
         #   (results.solver.termination_condition == "optimal"):
             # Do something when the solution in optimal and feasible
         self.solutions.load_from(results)
-
         if verbose:
-            print('***************************************************')
-            print('Optimization problem informations from solph')
-            print('****************************************************')
+            logging.info('**************************************************')
+            logging.info('Optimization problem informations from solph')
+            logging.info('**************************************************')
             for k in results:
-              print(k, results[k])
+              logging.info('{0}: {1}'.format(k, results[k]))
+        else:
+            logging.debug('**************************************************')
+            logging.debug('Optimization problem informations from solph')
+            logging.debug('**************************************************')
+            for k in results:
+              logging.debug('{0}: {1}'.format(k, results[k]))
         return results
 
 

--- a/oemof/tools/helpers.py
+++ b/oemof/tools/helpers.py
@@ -143,9 +143,9 @@ def get_polygon_from_shp_file(file):
     use the function.
 
     >>> a=[1,2,3]
-    >>> print [x + 3 for x in a]
+    >>> print([x + 3 for x in a])
     [4, 5, 6]
-    >>> print "a\n\nb"
+    >>> print("a\nb")
     a
     b
 

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -16,7 +16,40 @@ from oemof.tools import helpers
 def define_logging(inifile='logging.ini', basicpath=None, subdir='log_files'):
     r"""Initialise the logger using the logging.conf file in the local path.
 
-    '''
+    Several sentences providing an extended description. Refer to
+    variables using back-ticks, e.g. `var`.
+
+    Parameters
+    ----------
+    inifile : string, optional (default: logging.ini)
+        Name of the configuration file to define the logger. If no ini-file
+        exist a default ini-file will be downloaded from
+        'http://vernetzen.uni-flensburg.de/~git/logging_default.ini' and used.
+    basicpath : string, optional (default: '.oemof' in HOME)
+        The basicpath for different oemof related informations. By default
+        a ".oemof' folder is created in your home directory.
+    subdir : string, optional (default: 'log_files')
+        The name of the subfolder of the basicpath where the log-files are
+        stored.
+
+    Notes
+    -----
+    By default the INFO level is printed on the screen and the debug level
+    in a file.
+
+    Examples
+    --------
+    To define the default logge you have to import the python logging library
+    and this function.
+
+    >>> import logging
+    >>> from oemof.tools import logger
+    >>> logger.define_logging()
+    [...]INFO-Path for logging:...
+    [...]INFO-Used oemof version:...
+    >>> logging.debug("Hallo")
+    
+    """
     url = 'http://vernetzen.uni-flensburg.de/~git/logging_default.ini'
     if basicpath is None:
         basicpath = helpers.get_basic_path()

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -44,7 +44,7 @@ def define_logging(inifile='logging.ini', basicpath=None, subdir='log_files'):
 
     >>> import logging
     >>> from oemof.tools import logger
-    >>> logger.define_logging()
+    >>> logger.define_logging() # doctest: +SKIP
     [...]INFO-Path for logging:...
     [...]INFO-Used oemof version:...
     >>> logging.debug("Hallo")

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -54,6 +54,6 @@ def check_git_branch():
     last_commit = f.read(8)
     f.close()
 
-    logging.info("Used oemof version: {0} @ {1}".format(
+    logging.info("Used oemof version: {0}@{1}".format(
         last_commit,
         name_branch))

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -65,7 +65,16 @@ def define_logging(inifile='logging.ini', basicpath=None, subdir='log_files'):
     logger = logging.getLogger('simpleExample')
     logger.debug('*********************************************************')
     logging.info('Path for logging: %s' % logpath)
-    check_git_branch()
+    try:
+        check_git_branch()
+    except:
+        check_version()
+
+
+def check_version():
+    """Returns the actual version number of the used oemof version."""
+    # TODO : Please add this feature if you know how.
+    pass
 
 
 def check_git_branch():
@@ -93,10 +102,10 @@ def check_git_branch():
     logging.info("Used oemof version: {0}@{1}".format(
         last_commit,
         name_branch))
-        
+
 if __name__ == '__main__':
     import doctest
-    
+
     OC = doctest.OutputChecker
     class AEOutputChecker(OC):
         def check_output(self, want, got, optionflags):

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -35,20 +35,24 @@ def define_logging(inifile='logging.ini', basicpath=None, subdir='log_files'):
     Notes
     -----
     By default the INFO level is printed on the screen and the debug level
-    in a file.
+    in a file, but you can easily configure the ini-file.
+    Every module that wants to create logging messages has to import the
+    logging module. The oemof logger module has to be imported once to
+    initialise it.
 
     Examples
     --------
     To define the default logge you have to import the python logging library
-    and this function.
+    and this function. The first logging message should be the path where the
+    log file is saved to.
 
     >>> import logging
     >>> from oemof.tools import logger
     >>> logger.define_logging() # doctest: +SKIP
-    [...]INFO-Path for logging:...
-    [...]INFO-Used oemof version:...
+    17:56:51-INFO-Path for logging: /HOME/.oemof/log_files
+    ...
     >>> logging.debug("Hallo")
-    
+
     """
     url = 'http://vernetzen.uni-flensburg.de/~git/logging_default.ini'
     if basicpath is None:

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -89,3 +89,17 @@ def check_git_branch():
     logging.info("Used oemof version: {0}@{1}".format(
         last_commit,
         name_branch))
+        
+if __name__ == '__main__':
+    import doctest
+    
+    OC = doctest.OutputChecker
+    class AEOutputChecker(OC):
+        def check_output(self, want, got, optionflags):
+            from re import sub
+            if optionflags & doctest.ELLIPSIS:
+                want = sub(r'\[\.\.\.\]', '...', want)
+            return OC.check_output(self, want, got, optionflags)
+
+    doctest.OutputChecker = AEOutputChecker
+    doctest.testmod(verbose=True, optionflags=doctest.ELLIPSIS)

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -13,15 +13,14 @@ import logging.config
 from oemof.tools import helpers
 
 
-def define_logging(logging_dir='log_files'):
-    '''
-    Initialise the logger using the logging.conf file in the local path
+def define_logging(inifile='logging.ini', basicpath=None, subdir='log_files'):
+    r"""Initialise the logger using the logging.conf file in the local path.
 
-    Uwe Krien (uwe.krien@rl-institut.de)
     '''
     url = 'http://vernetzen.uni-flensburg.de/~git/logging_default.ini'
-    basicpath = helpers.get_basic_path()
-    logpath = helpers.extend_basic_path(logging_dir)
+    if basicpath is None:
+        basicpath = helpers.get_basic_path()
+    logpath = helpers.extend_basic_path(subdir)
     log_filename = os.path.join(basicpath, 'logging.ini')
     if not os.path.isfile(log_filename):
         helpers.download_file(log_filename, url)


### PR DESCRIPTION
Therefore we have to be sure that  at least a basic logger is defined otherwise there won't appear anything on the screen. So I defined a very basic logger to see the message on the screen.

It is still possible to use the default oemof logger described  in issue #28.

The advantage is that you can see the message on the screen and(!) in the file. Furthermore it is configurable so that you can decide what level you want to see, and what level you want to log in a file.

 See the following link for more information: https://docs.python.org/3/howto/logging.html

@oemof/oemof-main : Is it okay to merge it?